### PR TITLE
softetherVPN：增加进程奔溃检测

### DIFF
--- a/src/softether/softether/scripts/softether_status.sh
+++ b/src/softether/softether/scripts/softether_status.sh
@@ -4,7 +4,7 @@ source /jffs/softcenter/scripts/base.sh
 
 pid=`pidof vpnserver`
 if [ -n "$pid" ];then
-	http_response "softether 进程运行正常，pid：$pid"
+	http_response "vpnserver 进程运行中，pid：$pid"
 else
-	http_response "<span style='color: white'>softether 进程未运行！</span>"
+	http_response "<span style='color: white'>vpnserver 进程未运行！</span>"
 fi

--- a/src/softether/softether/webs/Module_softether.asp
+++ b/src/softether/softether/webs/Module_softether.asp
@@ -107,6 +107,9 @@ function get_dbus_data() {
 			if(db_softether["softether_AutoSaveConfigSpan"]){
 				E("softether_AutoSaveConfigSpan").value = db_softether["softether_AutoSaveConfigSpan"];
 			}
+			if(db_softether["softether_watch_time"]){
+				E("softether_watch_time").value = db_softether["softether_watch_time"];
+			}
 			//TMP模式开始
 			E("softether_conf_TMP").checked = db_softether["softether_conf_TMP"] == "1";
 			if(db_softether["softether_conf_cron_time"]){
@@ -161,6 +164,7 @@ function onSubmitCtrl() {
 	db_softether["softether_udp_ports"] = E("softether_udp_ports").value;
 	db_softether["softether_DisableJsonRpcWebApi"] = E("softether_DisableJsonRpcWebApi").value;
 	db_softether["softether_AutoSaveConfigSpan"] = E("softether_AutoSaveConfigSpan").value;
+	db_softether["softether_watch_time"] = E("softether_watch_time").value;
 	
 	//TMP模式开始
 	db_softether["softether_conf_TMP"] = E("softether_conf_TMP").checked ? '1' : '0';
@@ -352,6 +356,11 @@ function open_hint(itemNum) {
 		statusmenu += "&nbsp;&nbsp;2. 某些版本AutoSaveConfigSpan最大3600秒（默认300），若觉得不够大，或不需要统计数据，可试用此模式。此模式下想要保留部分统计数据，可修改AutoSaveConfigSpan为较小的值，然后设置定时保存。"
 		_caption = "配置文件TMP模式";
 	}
+	if (itemNum == 9) {
+		statusmenu = "&nbsp;使用系统定时服务检测vpnserver进程，发现异常进行修复。若运行良好，禁用即可。若有以下异常，建议开启：<br/>"
+		statusmenu += "&nbsp;&nbsp;1. 进程丢失。<br/>&nbsp;&nbsp;2. 进程虽在运行，但无法连接VPN服务。可能是因某些原因，进程发生奔溃后自动重启（pid会变），导致虚拟网卡桥接失效而无法访问。"
+		_caption = "进程检测间隔时间";
+	}
 
 	return overlib(statusmenu, OFFSETX, -140, OFFSETY, 5, LEFT, STICKY, WIDTH, 'width', CAPTION, _caption, CLOSETITLE, '');
 
@@ -491,6 +500,26 @@ function mOut(obj){
 												<label><input type="checkbox" id="softether_udp_v6" name="softether_udp_v6"><i>包含ipv6</i></label></th>
 												<td>
 													<input type="text" oninput="this.value=this.value.replace(/[^\d ]/g, '')" class="input_ss_table" id="softether_udp_ports" name="softether_udp_ports" maxlength="100" value="" placeholder="空格隔开" />
+												</td>
+											</tr>
+											<tr id="watch_time_tr">
+											<th><a onmouseover="mOver(this, 9)" onmouseout="mOut(this)" class="hintstyle" href="javascript:void(0);">进程检测间隔时间</a></th>
+												<td>
+													<select id="softether_watch_time" name="softether_watch_time" style="width:60px;vertical-align: middle;" class="input_option">
+															<option value="">禁用</option>
+															<option value="1">1</option>
+															<option value="2">2</option>
+															<option value="3">3</option>
+															<option value="4">4</option>
+															<option value="5">5</option>
+															<option value="6">6</option>
+															<option value="10">10</option>
+															<option value="12">12</option>
+															<option value="15">15</option>
+															<option value="20">20</option>
+															<option value="30">30</option>
+															<option value="60">60</option>
+														</select>&nbsp;<span>分钟</span>
 												</td>
 											</tr>
 											<thead>


### PR DESCRIPTION
改动：增加定时检测进程pid变化、并修复网桥的脚本。
动机：新版主程序v4.44，有时候会崩溃，然后自动重新启动，这会导致虚拟tap设备与br0的桥接失效。
原因：可能跟弱网有关。
在与异地级联组网时，测试分别连接2个v4.38的服务器，其中1个高峰期运营商限速（限制上传）较严重，会不定期进程崩溃（每周2~3次）；另1个也有限速但限速轻一些，并无异常。
用的是9月份更新的v4.44，这版cpu负载感觉小一点，但出现奔溃，以前的v4.29没有发生过（平台bcm6755）。

崩溃时系统日志摘抄：
```
Nov 15 20:57:01 kernel: CPU: 2 PID: 3320 Comm: vpnserver Tainted: P           O    4.1.52 #1
Nov 15 20:57:01 kernel: Hardware name: Generic DT based system
Nov 15 20:57:01 kernel: task: d10fbc00 ti: d597e000 task.ti: d597e000
Nov 15 20:57:01 kernel: PC is at 0x322fac
Nov 15 20:57:01 kernel: LR is at 0x1eaf04
Nov 15 20:57:01 kernel: pc : [<00322fac>]    lr : [<001eaf04>]    psr: 60000010
Nov 15 20:57:01 kernel: sp : b5ecc4e8  ip : 00000000  fp : 00000000
Nov 15 20:57:01 kernel: r10: 00000000  r9 : b5ecc660  r8 : b5ecc61c
Nov 15 20:57:01 kernel: r7 : 00000000  r6 : 62d71077  r5 : 00000000  r4 : 000007dd
Nov 15 20:57:01 kernel: r3 : 00000010  r2 : 00000010  r1 : b5ecc540  r0 : 00000010
Nov 15 20:57:01 kernel: Flags: nZCv  IRQs on  FIQs on  Mode USER_32  ISA ARM  Segment user
Nov 15 20:57:01 kernel: Control: 10c5387d  Table: 1114004a  DAC: 00000015
Nov 15 20:57:01 kernel: CPU: 2 PID: 3320 Comm: vpnserver Tainted: P           O    4.1.52 #1
Nov 15 20:57:01 kernel: Hardware name: Generic DT based system
Nov 15 20:57:01 kernel: [<c00270a0>] (unwind_backtrace) from [<c0022cf8>] (show_stack+0x10/0x14)
Nov 15 20:57:01 kernel: [<c0022cf8>] (show_stack) from [<c04946e0>] (dump_stack+0x8c/0xa0)
Nov 15 20:57:01 kernel: [<c04946e0>] (dump_stack) from [<c003ad2c>] (get_signal+0x490/0x558)
Nov 15 20:57:01 kernel: [<c003ad2c>] (get_signal) from [<c0022290>] (do_signal+0xc8/0x3ac)
Nov 15 20:57:01 kernel: [<c0022290>] (do_signal) from [<c0022718>] (do_work_pending+0x94/0xa4)
Nov 15 20:57:01 kernel: [<c0022718>] (do_work_pending) from [<c001f58c>] (work_pending+0xc/0x20)
```
